### PR TITLE
Fix mode backup-age on SQL Server 2000

### DIFF
--- a/plugins-scripts/Nagios/DBD/MSSQL/Server/Database.pm
+++ b/plugins-scripts/Nagios/DBD/MSSQL/Server/Database.pm
@@ -332,7 +332,13 @@ my %ERRORCODES=( 0 => 'OK', 1 => 'WARNING', 2 => 'CRITICAL', 3 => 'UNKNOWN' );
         } else {
           @databaseresult = $params{handle}->fetchall_array(q{
             SELECT
-              a.name, a.recovery_model,
+              a.name,
+              CASE databasepropertyex(a.name, 'Recovery')
+                WHEN 'FULL' THEN 1
+                WHEN 'BULK_LOGGED' THEN 2
+                WHEN 'SIMPLE' THEN 3
+                ELSE 0
+              END AS recovery_model,
               DATEDIFF(HH, MAX(b.backup_finish_date), GETDATE()),
               DATEDIFF(MI, MAX(b.backup_start_date), MAX(b.backup_finish_date))
             FROM master.dbo.sysdatabases a LEFT OUTER JOIN msdb.dbo.backupset b


### PR DESCRIPTION
SQL query used in mode backup-age does not work in SQL Server 2000
(version 8.0). On this version, column recovery_model does not exist
in table master.dbo.sysdatabases.

Mon Jun 24 14:21:01 2013: bumm DBD::Sybase::st execute failed: \
    Server message number=207 severity=16 state=3 line=2 \
    server=mssql-2b text=Invalid column name 'recovery_model'.  \
    at /tmp/check_mssql_health line 3158.

CRITICAL - unable to aquire database info

This patch is based on the following post:
http://www.sqlservercentral.com/Forums/Topic1182788-5-1.aspx#bm1182799

> In SQL 2000, the recovery model is not displayed in the system
> catalogue like it is in 2005. However, thanks to the magic of
> functions you can retrieve it by using the following script.
> 
> select name, databasepropertyex(name, 'Recovery') as RecoveryModel
> from master.dbo.sysdatabases
> order by name
