### PR TITLE
Fix call stored procedure started with declare

### DIFF
--- a/plugins-scripts/Nagios/DBD/MSSQL/Server.pm
+++ b/plugins-scripts/Nagios/DBD/MSSQL/Server.pm
@@ -1498,13 +1498,8 @@ sub fetchrow_array {
     } else {
       $sth->execute() || die DBI::errstr();
     }
-    if (lc $sql =~ /^\s*(exec |sp_)/ || $sql =~ /^\s*exec sp/im) {
-      # flatten the result sets
-      do {
-        while (my $aref = $sth->fetchrow_arrayref()) {
-          push(@row, @{$aref});
-        }
-      } while ($sth->{syb_more_results});
+    if (lc $sql =~ /(exec |sp_)/) {
+      @row = $sth->syb_output_params();
     } else {
       @row = $sth->fetchrow_array();
     }


### PR DESCRIPTION
Example of procedure which returned ZERO (error) when executed

"declare @hours_Since_Last_Backup int exec sp_hours_since_last_backup 'base','Y','Z', @hours_Since_Last_Backup output"
