### PR TITLE
Exclude tempdb from database-backup-age and database-logbackup-age

### DIFF
--- a/plugins-scripts/Classes/MSSQL/Component/DatabaseSubsystem.pm
+++ b/plugins-scripts/Classes/MSSQL/Component/DatabaseSubsystem.pm
@@ -163,7 +163,7 @@ sub init {
             GROUP BY
                 bs.database_name
           ) bs1 ON
-              d.name = bs1.database_name WHERE d.source_database_id IS NULL
+              d.name = bs1.database_name WHERE d.source_database_id IS NULL AND d.name != 'tempdb'
           ORDER BY
               d.name
         };
@@ -210,7 +210,7 @@ sub init {
             GROUP BY
                 bs.database_name
           ) bs1 ON
-              d.name = bs1.database_name WHERE d.source_database_id IS NULL
+              d.name = bs1.database_name WHERE d.source_database_id IS NULL AND d.name != 'tempdb'
           ORDER BY
               d.name
         };


### PR DESCRIPTION
The tempdb couldn't be backuped. The check is always CRITICAL when no database is specified.

CRITICAL - tempdb was never backed up, ...


