### PR TITLE
Removed unused INNER JOIN

### DIFF
--- a/plugins-scripts/Classes/MSSQL/Component/AvailabilitygroupSubsystem.pm
+++ b/plugins-scripts/Classes/MSSQL/Component/AvailabilitygroupSubsystem.pm
@@ -56,7 +56,6 @@ sub init {
           [rs].[replica_id],
           [rs].[group_database_id]
         FROM [master].[sys].[availability_groups] AS [ag]
-        INNER JOIN [master].[sys].[dm_hadr_availability_group_states] AS [gs] ON [ag].[group_id] = [gs].[group_id]
         INNER JOIN [master].[sys].[dm_hadr_database_replica_states] AS [rs] ON [ag].[group_id] = [rs].[group_id]
         INNER JOIN [master].[sys].[databases] AS [db] ON [rs].[database_id] = [db].[database_id]
       };


### PR DESCRIPTION
Removed unused inner join.
Slows Down Query significantly!

with 26 AVGs the query took 15 seconds with and 1 second without it.
[gs] is not used.