### PR TITLE
Update DBI.pm Simplify database name assignment and bypass syb_db_use…

### DIFF
--- a/plugins-scripts/Classes/Sybase/DBI.pm
+++ b/plugins-scripts/Classes/Sybase/DBI.pm
@@ -15,14 +15,7 @@ sub check_connect {
     $dsn .= sprintf ";server=%s", $self->opts->server;
   }
   $dsn .= ";encryptPassword=1";
-  if ($self->opts->currentdb) {
-    if (index($self->opts->currentdb,"-") != -1) {
-      # once the database name had to be put in quotes....
-      $dsn .= sprintf ";database=%s", $self->opts->currentdb;
-    } else {
-      $dsn .= sprintf ";database=%s", $self->opts->currentdb;
-    }
-  }
+  
   if (basename($0) =~ /_sybase_/) {
     $dbi_options->{syb_chained_txn} = 1;
     $dsn .= sprintf ";tdsLevel=CS_TDS_42";
@@ -43,6 +36,10 @@ sub check_connect {
         $self->opts->password,
         $dbi_options)) {
       $Monitoring::GLPlugin::DB::session = $self->{handle};
+
+      if ($self->opts->currentdb) {
+        $self->{handle}->do("USE " . $self->opts->currentdb);
+      }
     }
     $self->{tac} = Time::HiRes::time();
     $Monitoring::GLPlugin::DB::session->{syb_flush_finish} = 1;


### PR DESCRIPTION
Update DBI.pm Simplify database name assignment and bypass syb_db_use() for direct database switch
- Removed unnecessary condition that added quotes around database names with hyphens, simplifying the assignment of the database parameter.
- Addressed an issue with syb_db_use() truncating database names after 32chars in ct_command by bypassing the DSN "database" parameter entirely.
- Instead, added an explicit "USE <database>" statement post-connection, ensuring the correct database context without triggering truncation behavior.

This update improves connection stability and prevents issues with database names exceeding length limits, as encountered in some Sybase or FreeTDS configurations.