### PR TITLE
Add conditional quoting for database name and bypass syb_db_use() tru…

### DIFF
--- a/plugins-scripts/Classes/Sybase/DBI.pm
+++ b/plugins-scripts/Classes/Sybase/DBI.pm
@@ -8,6 +8,8 @@ sub check_connect {
   my $stderrvar;
   my $dbi_options = { RaiseError => 1, AutoCommit => $self->opts->commit, PrintError => 1 };
   my $dsn = "DBI:Sybase:";
+  my $dbname;
+  
   if ($self->opts->hostname) {
     $dsn .= sprintf ";host=%s", $self->opts->hostname;
     $dsn .= sprintf ";port=%s", $self->opts->port;
@@ -16,11 +18,11 @@ sub check_connect {
   }
   $dsn .= ";encryptPassword=1";
   if ($self->opts->currentdb) {
-    if (index($self->opts->currentdb,"-") != -1) {
+    if (index($self->opts->currentdb, "-") != -1 || index($self->opts->currentdb, ".") != -1) {
       # once the database name had to be put in quotes....
-      $dsn .= sprintf ";database=%s", $self->opts->currentdb;
+      $dbname = sprintf "\"%s\"", $self->opts->currentdb;
     } else {
-      $dsn .= sprintf ";database=%s", $self->opts->currentdb;
+      $dbname = sprintf "%s", $self->opts->currentdb;
     }
   }
   if (basename($0) =~ /_sybase_/) {
@@ -43,6 +45,10 @@ sub check_connect {
         $self->opts->password,
         $dbi_options)) {
       $Monitoring::GLPlugin::DB::session = $self->{handle};
+      if ($self->opts->currentdb) {
+        $self->{handle}->do("USE " . $dbname);
+      }
+
     }
     $self->{tac} = Time::HiRes::time();
     $Monitoring::GLPlugin::DB::session->{syb_flush_finish} = 1;


### PR DESCRIPTION
…ncation issue

- Updated database name assignment to add quotes if the name contains a hyphen (-) or dot (.), improving compatibility with database names requiring special handling.
- Addressed an issue with syb_db_use() truncating database names after 32 characters in ct_command by bypassing the DSN "database" parameter entirely.
- Added an explicit "USE <database>" statement post-connection to set the database context directly, avoiding truncation issues in Sybase or FreeTDS configurations.

These changes enhance connection stability and ensure proper handling of database names with special characters or length limitations.