### PR TITLE
conditional quoting for database name and bypass syb_db_use() 

### DIFF
--- a/plugins-scripts/Classes/Sybase/DBI.pm
+++ b/plugins-scripts/Classes/Sybase/DBI.pm
@@ -17,8 +17,11 @@ sub check_connect {
   }
   $dsn .= ";encryptPassword=1";
   if ($self->opts->currentdb) {
-    # Falls ein Bindestrich im Namen enthalten ist, füge den Namen in Anführungszeichen hinzu, andernfalls direkt
-    if (index($self->opts->currentdb, "-") != -1 || index($self->opts->currentdb, ".") != -1) || index($self->opts->currentdb, "_") != -1) {
+    # Falls ein Bindestrich, Punkt, Untersrich oder Leerzeichen im Namen enthalten ist, füge den Namen in Anführungszeichen hinzu, andernfalls direkt
+    if (index($self->opts->currentdb, "-") != -1 
+    || index($self->opts->currentdb, ".") != -1 
+    || index($self->opts->currentdb, "_") != -1 
+    || index($self->opts->currentdb, " ") != -1) {
         $dbname = sprintf "\"%s\"", $self->opts->currentdb;
     } else {
         $dbname = sprintf "%s", $self->opts->currentdb;

--- a/plugins-scripts/Classes/Sybase/DBI.pm
+++ b/plugins-scripts/Classes/Sybase/DBI.pm
@@ -18,7 +18,7 @@ sub check_connect {
   $dsn .= ";encryptPassword=1";
   if ($self->opts->currentdb) {
     # Falls ein Bindestrich im Namen enthalten ist, füge den Namen in Anführungszeichen hinzu, andernfalls direkt
-    if (index($self->opts->currentdb, "-") != -1) {
+    if (index($self->opts->currentdb, "-") != -1 || index($self->opts->currentdb, ".") != -1) || index($self->opts->currentdb, "_") != -1) {
         $dbname = sprintf "\"%s\"", $self->opts->currentdb;
     } else {
         $dbname = sprintf "%s", $self->opts->currentdb;


### PR DESCRIPTION
- Updated database name assignment to add quotes if the name contains a hyphen (-), underscore (_) or dot (.), improving compatibility with database names requiring special handling.
- Addressed an issue with syb_db_use() truncating database names after 32 characters in ct_command by bypassing the DSN "database" parameter entirely.
- Added an explicit "USE <database>" statement post-connection to set the database context directly, avoiding truncation issues in Sybase or FreeTDS configurations.

These changes enhance connection stability and ensure proper handling of database names with special characters or length limitations.